### PR TITLE
Add OAuth Provider library for PHP

### DIFF
--- a/includes/_libraries.md
+++ b/includes/_libraries.md
@@ -11,6 +11,7 @@
 
 #### PHP
 * [A simple Ecwid oAuth2 client](https://github.com/Ecwid/ecwid-oauth2-client-php)
+* [Alternative Ecwid OAuth 2.0 Client Provider](https://github.com/mugnate/oauth2-ecwid) for The PHP League OAuth2-Client with packagist support
 * [Connect your app with MailChimp](https://github.com/jp26jp/Ecwid-Third-Party-App-MailChimp-Integration)
 
 #### C#


### PR DESCRIPTION
Add alternative Ecwid OAuth 2.0 Client Provider for The PHP League OAuth2-Client with packagist support. Also library approved as Third-Party Provider to [OAuth2-Client](http://oauth2-client.thephpleague.com/providers/thirdparty/)